### PR TITLE
Quay integration

### DIFF
--- a/.github/workflows/quay.yml
+++ b/.github/workflows/quay.yml
@@ -1,0 +1,29 @@
+name: Quay
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-[0-9]+"
+  workflow_dispatch:
+
+env:
+  REGISTRY: quay.io
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Registry login
+        run: echo "${{ secrets.QUAY_TOKEN }}" | podman login ${REGISTRY} -u ${{ secrets.QUAY_USER }} --password-stdin
+
+      - name: Build and Push images
+        run: |
+          ORG=${GITHUB_REPOSITORY%/*}
+          TAG=$(git tag --points-at HEAD)
+          VERSION=${TAG/v/}
+          make all ORG=${ORG} VERSION=${VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v1.5.0
+FROM quay.io/operator-framework/ansible-operator:v1.7.2
 
 MAINTAINER skramaja@redhat.com
 

--- a/relatedImages.yaml
+++ b/relatedImages.yaml
@@ -1,0 +1,5 @@
+  relatedImages:
+    - name: testpmd-container-app-testpmd
+      image: "quay.io/rh-nfv-int/testpmd-container-app-testpmd@sha256:22e45c9b3414e801cc65cc1411e27a51d4775fa3ee8a8893ea6026b2f246f6" # v0.2.0
+    - name: testpmd-container-app-listener
+      image: "quay.io/rh-nfv-int/testpmd-container-app-listener@sha256:b592ff00f09b3290a3abc33367817439d970f55754c9eb4467e003c4d329bde0" # v0.2.0

--- a/roles/loadbalancer/defaults/main.yml
+++ b/roles/loadbalancer/defaults/main.yml
@@ -1,14 +1,11 @@
 ---
-registry: quay.io
-org: rh-nfv-int
-version: v0.2.0
 image_pull_policy: IfNotPresent
 privileged: false
 network_defintions: ""
 environments: {}
 
-image_testpmd: "{{ registry }}/{{ org }}/testpmd-container-app-testpmd:{{ version }}"
-image_listener: "{{ registry }}/{{ org }}/testpmd-container-app-listener:{{ version }}"
+image_testpmd: "quay.io/rh-nfv-int/testpmd-container-app-testpmd@sha256:22e45c9b3414e801cc65cc1411e27a51d4775fa3ee8a8893ea6026b2f246f6" # v0.2.0
+image_listener: "quay.io/rh-nfv-int/testpmd-container-app-listener@sha256:b592ff00f09b3290a3abc33367817439d970f55754c9eb4467e003c4d329bde0" # v0.2.0
 
 hugepage_1gb_count: 4Gi
 memory: 1000Mi


### PR DESCRIPTION
Another as in [testpmd-operator](https://github.com/rh-nfv-int/testpmd-operator/pull/7), and [trex-operator](https://github.com/rh-nfv-int/trex-operator/pull/3) This creates a workflow to build the operator and the bundle on a tagged release. The result artifacts are published in quay.io

- Extends `Makefile` to build/push operator and bundle, and install operator-sdk. Supporting SHA2 digest
- Makes use of digest in the images used by the operator, is still possible to use other images by specifying the full URL
- Adds `relatedImages` to support SHA2 digest (allowing disconnected)
- Lastly it upgrades the operator image to `v1.7.2`

I've tested this flow in my repo and my registry to store the images generated. The output of the [GH Action is here ](https://github.com/tonyskapunk/testpmd-lb-operator/runs/2899551442)

---

cc: @betoredhat, @krsacme 