### PR TITLE
Bump version to 0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] -
 
+## [0.2.6] - 2021-07-28
+
+- No changes, just bumping version to align to other operators (testpmd, cnf-app-mac, trex)
+
 ## [0.2.5] - 2021-06-29
 
 - Added support to disconnected environments (SHA2 digest)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Current Operator version
-VERSION         := 0.2.5
+VERSION         := 0.2.6
 TAG             := v$(VERSION)
 REGISTRY        ?= quay.io
 ORG             ?= rh-nfv-int


### PR DESCRIPTION
 - No changes, just bumping version to align to other operators (testpmd, cnf-app-mac, trex)