### PR TITLE
Bring parity to ansible-operator from operator-sdk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,21 +95,17 @@ ifeq (,$(wildcard $(OPERATOR_SDK)))
 else
 endif
 
-# Download ansible-operator locally if necessary, preferring the $(pwd)/bin path over global if both exist.
+# Download ansible-operator locally if necessary in $(pwd)/bin
 .PHONY: ansible-operator
 ANSIBLE_OPERATOR = $(shell pwd)/bin/ansible-operator
 ansible-operator:
 ifeq (,$(wildcard $(ANSIBLE_OPERATOR)))
-ifeq (,$(shell which ansible-operator 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(ANSIBLE_OPERATOR)) ;\
-	curl -sSLo $(ANSIBLE_OPERATOR) https://github.com/operator-framework/operator-sdk/releases/download/v1.3.0/ansible-operator_$(OS)_$(ARCH) ;\
+	curl -sSLo $(ANSIBLE_OPERATOR) https://github.com/operator-framework/operator-sdk/releases/download/v$(OPERATOR_SDK_VER)/ansible-operator_$(OS)_$(ARCH) ;\
 	chmod +x $(ANSIBLE_OPERATOR) ;\
 	}
-else
-ANSIBLE_OPERATOR = $(shell which ansible-operator)
-endif
 endif
 
 # Generate bundle manifests and metadata, then validate generated files.


### PR DESCRIPTION
This change does not modify the operator itself, just the version of the ansible-operator that's used to deploy it directly
